### PR TITLE
Fix state set issue to cause focus circle to stay after focus out

### DIFF
--- a/frontend/src/common/containers/Gallery/components/Thumbnails.js
+++ b/frontend/src/common/containers/Gallery/components/Thumbnails.js
@@ -23,17 +23,16 @@ const Thumbnails = ({ highlight, zone }) => {
     setFocus({ ...focus, state: true, x: x, y: y, scale: 7 });
     let target = array.chips[zone][key];
     if (target.color === "transparent") {
+      target.color = marker.color._zoom
+      target.radius = marker.radius._zoom
       setArray({
         ...array,
         chips: {
           ...array.chips,
           [zone]: {
             ...array.chips[zone],
-            [key]: {
-              ...array.chips[zone][key],
-              color: marker.color._zoom,
-              radius: marker.radius._zoom,
-            },
+            [key]: target
+            ,
           },
         },
       });
@@ -44,17 +43,15 @@ const Thumbnails = ({ highlight, zone }) => {
     setFocus({ ...focus, state: false, x: 0, y: 0, scale: 1 });
     let target = array.chips[zone][key];
     if (target.color === "chartreuse") {
+      target.color = marker.color._default
+      target.radius = marker.radius._default
       setArray({
         ...array,
         chips: {
           ...array.chips,
           [zone]: {
             ...array.chips[zone],
-            [key]: {
-              ...array.chips[zone][key],
-              color: marker.color._default,
-              radius: marker.radius._default,
-            },
+            [key]: target,
           },
         },
       });


### PR DESCRIPTION
# Description

> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Circle to indicate where user focus in stays after quickly focusing out and focusing in on another image.

## Fixes / issues

Fix state set issue to cause focus circle to stay after focus out

## Type of change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.