### PR TITLE
v1.x amend threshold to take chip size instead of defect size

### DIFF
--- a/backend/conf/json/settings.json
+++ b/backend/conf/json/settings.json
@@ -14,7 +14,7 @@
     },
     "thres_range": {
       "low_chip": 0.15,
-      "upp_chip": 3,
+      "upp_chip": 2,
       "low_defect": 0.75,
       "upp_defect": 1.5
     }

--- a/backend/src/apis/utils/chip_process.py
+++ b/backend/src/apis/utils/chip_process.py
@@ -90,7 +90,7 @@ def get_chips(
     pady,
     ai,
 ):
-    cnt_arr = check_single(blank.copy(), cnt, upp_def_area)
+    cnt_arr = check_single(blank.copy(), cnt, upp_c_area)
     for c, cArea in cnt_arr:
         if low_c_area < cArea < upp_c_area:
             rect = cv2.minAreaRect(c)


### PR DESCRIPTION
## Previous Context

## Description

> Please provide a detailed or a short description of the issues

Check single using wrong threshold for checking chip size. 

## Solution / Fixes

Change defect size threshold to chip size threshold.
Lower chip size threshold from 3 to 2.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
