### PR TITLE
FEAT: extract crop size from constants into json. updated tests

### DIFF
--- a/backend/src/core/constants.py
+++ b/backend/src/core/constants.py
@@ -1,8 +1,5 @@
 # Constants and default settings for image processing and configurations.
 
-# Size of cropped chips
-CHIP_CROP_SIZE: list[int] = [54, 54]
-
 # Valid types for "G"
 G_TYPES: list[str] = ["G", "Good", "g", "good"]
 
@@ -17,7 +14,7 @@ SETTINGS_MODE: list[str] = ["erode", "close"]
 # Default settings for batch and chip processing
 DEFAULT_SETTINGS: dict[str, dict[str, list[int]]] = {
     "batch": {"erode": [1, 1], "close": [1, 1]},
-    "chip": {"erode": [1, 1], "close": [1, 1]},
+    "chip": {"erode": [1, 1], "close": [1, 1], "crop": [54, 54]},
 }
 
 # Default colors for various categories

--- a/backend/src/utils/imageProcess/image_process.py
+++ b/backend/src/utils/imageProcess/image_process.py
@@ -21,7 +21,9 @@ def image_process(
     start, stdout = time_print("Start Processing Image")
     logger.info(stdout)
 
-    border_image, border_gray = create_border_image(image)
+    border_image, border_gray = create_border_image(
+        image, settings_data["chip"]["crop"]
+    )
 
     lap, stdout = time_print("Creating border image and border gray image", start)
     logger.info(stdout)

--- a/backend/src/utils/imageProcess/image_utils.py
+++ b/backend/src/utils/imageProcess/image_utils.py
@@ -4,19 +4,18 @@ import math
 import numpy as np
 
 from core.exceptions import ImageProcessError
-import core.constants as core_consts
 import utils.imageProcess.constants as imageProcess_constants
 from core.logging import logger
 
 
-def create_border_image(image: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def create_border_image(
+    image: np.ndarray, crop_settings: list[str]
+) -> tuple[np.ndarray, np.ndarray]:
     """Return border extended MatLike image in BGR and Gray."""
 
     # Added border to include chips near the edge of images,
     # allowing better cropping of chips later on
-    padx, pady = [
-        math.ceil(x * math.sqrt(2) / 10) * 10 for x in core_consts.CHIP_CROP_SIZE
-    ]
+    padx, pady = [math.ceil(x * math.sqrt(2) / 10) * 10 for x in crop_settings]
     border_image = cv2.copyMakeBorder(
         image,
         pady,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -154,7 +154,7 @@ def sample_settings_group(
                 "item": sample_lot_details["item"],
                 "settings": {
                     "batch": {"erode": [1, 1], "close": [1, 1]},
-                    "chip": {"erode": [1, 1], "close": [1, 1]},
+                    "chip": {"erode": [1, 1], "close": [1, 1], "crop": [54, 54]},
                 },
             },
         ]

--- a/backend/tests/utils/test_fileHandle/test_json_validate_settings_format.py
+++ b/backend/tests/utils/test_fileHandle/test_json_validate_settings_format.py
@@ -7,7 +7,7 @@ def test_check_settings_format_valid() -> None:
     """Test check_settings_format with valid settings."""
     sample_settings = {
         "batch": {"erode": [1, 1], "close": [1, 1]},
-        "chip": {"erode": [1, 1], "close": [1, 1]},
+        "chip": {"erode": [1, 1], "close": [1, 1], "crop": [54, 54]},
     }
     assert validate_settings_format(sample_settings) is None
 
@@ -24,7 +24,7 @@ def test_check_settings_format_missing_sub_key() -> None:
     """Test check_settings_format with missing sub key."""
     sample_settings = {
         "batch": {"erode": [1, 1]},
-        "chip": {"erode": [1, 1], "close": [1, 1]},
+        "chip": {"erode": [1, 1], "close": [1, 1], "crop": [54, 54]},
     }
     assert (
         validate_settings_format(sample_settings)
@@ -36,7 +36,7 @@ def test_check_settings_format_invalid_list():
     """Test check_settings_format with invalid list format."""
     sample_settings = {
         "batch": {"erode": [1, 1], "close": (1, "invalid")},
-        "chip": {"erode": [1, 1], "close": [1, 1]},
+        "chip": {"erode": [1, 1], "close": [1, 1], "crop": [54, 54]},
     }
     assert (
         validate_settings_format(sample_settings)

--- a/backend/tests/utils/test_imageProcess/conftest.py
+++ b/backend/tests/utils/test_imageProcess/conftest.py
@@ -49,7 +49,7 @@ def sample_batch_config() -> dict[str, tuple[int, int]]:
 @pytest.fixture
 def sample_chip_config() -> dict[str, tuple[int, int]]:
     """Fixture to provide a sample chip configuration."""
-    return {"erode": (5, 5), "close": (2, 2)}
+    return {"erode": (5, 5), "close": (2, 2), "crop": [54, 54]}
 
 
 @pytest.fixture

--- a/backend/tests/utils/test_imageProcess/test_image_utils.py
+++ b/backend/tests/utils/test_imageProcess/test_image_utils.py
@@ -11,11 +11,19 @@ from utils.imageProcess.image_utils import (
 )
 
 
-def test_create_border_image(sample_images: dict[str, str | np.ndarray]) -> None:
+def test_create_border_image(
+    sample_images: dict[str, str | np.ndarray],
+    sample_settings_group: dict[
+        str, list[dict[str, str | dict[str, dict[str, list[int]]]]]
+    ],
+) -> None:
     """Test the creation of border images."""
 
     base_image = sample_images["base"]
-    border_image, border_gray = create_border_image(base_image)
+    border_image, border_gray = create_border_image(
+        base_image,
+        sample_settings_group["settingsGroup"][0]["settings"]["chip"]["crop"],
+    )
 
     np.testing.assert_array_equal(border_image, sample_images["border"])
     np.testing.assert_array_equal(border_gray, sample_images["gray"])


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Chip crop size is only changeable via constant which might not fit for all item size.

## Solution / Fixes

Extract the crop size from constant into json for dynamic changes when settings file is updated.
Updated test to fit changes.

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
