### PR TITLE
BUG: fix thumbnail not showing in CDC page

### DIFF
--- a/frontend/src/modules/Gallery/Gallery.jsx
+++ b/frontend/src/modules/Gallery/Gallery.jsx
@@ -17,10 +17,7 @@ const Gallery = ({ page }) => {
     if (!acc[batch]) {
       acc[batch] = [];
     }
-
-    const isMarkerZero = MARKERS.marks.some(
-      ({ id: markerId }) => markerId === 0,
-    );
+    const isMarkerZero = circle.id === 0;
     const isCDCPage = page.toUpperCase() === "CDC";
 
     if (isMarkerZero && isCDCPage) return acc;


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Thumbnail not showing for CDC page when image is loaded despite able to click and change marker colors 

## Solution / Fixes

the condition to show the thumbnails was not clearly defined properly. 
Amend to less complicated condition.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
