### PR TITLE
BUG: fix run save input after lot no was removed

### DIFF
--- a/frontend/src/modules/InfoBar/components/InfoBarUpload/components/ImageForm.jsx
+++ b/frontend/src/modules/InfoBar/components/InfoBarUpload/components/ImageForm.jsx
@@ -11,22 +11,19 @@ import {
 import { Input } from "@/components/ui/input";
 import HoverButton from "@/components/HoverButton";
 import useImageForm from "../hooks/useImageForm";
-import useSaveInput from "../hooks/useSaveInput";
 import { useInfoBarContext } from "@/modules/InfoBar/contexts/infoBarContext";
 
 const ImageForm = ({ page, fileInputRef }) => {
-  const saveUserInput = useSaveInput();
-  const [form_info, form] = useImageForm();
+  const [form_info, form] = useImageForm(page);
   const { updateInfoDetails } = useInfoBarContext();
 
   // Submit form data and trigger file input
   const onSubmit = useCallback(
     (onSubmitData) => {
-      saveUserInput(page);
       updateInfoDetails(onSubmitData);
       fileInputRef.current?.click();
     },
-    [fileInputRef, saveUserInput, page, updateInfoDetails],
+    [fileInputRef, updateInfoDetails],
   );
 
   // Handle form reset

--- a/frontend/src/modules/InfoBar/components/InfoBarUpload/hooks/useImageForm.js
+++ b/frontend/src/modules/InfoBar/components/InfoBarUpload/hooks/useImageForm.js
@@ -6,15 +6,18 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useFetch } from "@/hooks/useFetch";
 import { getItemType } from "@/services/api_retrieve";
 import { useInfoBarContext } from "@/modules/InfoBar/contexts/infoBarContext";
+import useSaveInput from "../hooks/useSaveInput";
 
 //TODO: Convert ItemType to combobox for typing and selection
 
-const useImageForm = () => {
+const useImageForm = (page) => {
+  const saveUserInput = useSaveInput();
   const { data, error, fetchData } = useFetch();
   const { infoDetails, updateInfoDetails } = useInfoBarContext();
 
   // Sync the image details from the fetch data or handle error
   useEffect(() => {
+    saveUserInput(page);
     updateInfoDetails(error ? { item: "" } : data);
   }, [data, error, updateInfoDetails]);
 


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

user input was not saved when uploading new images.

## Solution / Fixes

user input function was called after lot no value was updated to empty
fix the user input function to call before the lot no value was updated to empty.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
