### PR TITLE
BUG: amend locahost to localhost for default value

### DIFF
--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -30,7 +30,7 @@ class APISettings(Settings):
     """API-specific settings."""
 
     FASTAPI_ROOT: str = Field(default="api")
-    PC_NAME: str = Field(default="locahost")
+    PC_NAME: str = Field(default="localhost")
     SERVER_API_PORT: int = Field(default=8000)
     SERVER_APP_PORT: int = Field(default=5173)
     ALLOWED_CORS: list[str] = []


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

PC_NAME under config is set to default value of locahost

## Solution / Fixes

Change locahost to localhost

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
