### PR TITLE
BUG: main env load after backend env loaded

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -5,8 +5,8 @@ from dotenv import find_dotenv, load_dotenv
 
 def load_environment(env):
     """Load environment variables from .env files based on the environment."""
-    load_dotenv(dotenv_path=find_dotenv(f".env.{env}"))
     load_dotenv(dotenv_path=find_dotenv("../.env"))
+    load_dotenv(dotenv_path=find_dotenv(f".env.{env}"))
 
 
 def parse_arguments():


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Main env load after backend env loaded resulting in missing server app and server api port number

## Solution / Fixes

Load main env before backend env loaded

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
