### PR TITLE
BUG: add window resizing listener and optimize speed using Map

### DIFF
--- a/frontend/src/features/image-display/hooks/useMarkCanvas.js
+++ b/frontend/src/features/image-display/hooks/useMarkCanvas.js
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { MARKERS } from "@/core/constants";
 import useMarking from "@/hooks/useMarking";
 import { useImageStore } from "@/store/display";
+import { useEffect, useState } from "react";
 
 const useMarkCanvas = () => {
   const { data: processImageData } = useQuery({
@@ -15,25 +16,46 @@ const useMarkCanvas = () => {
   } = useMarking();
 
   const imageRef = useImageStore((state) => state.imageRef);
-  const rect = useMemo(
-    () => imageRef?.current?.getBoundingClientRect(),
-    [imageRef],
-  );
+
+  // Using useState and useEffect to track image dimensions
+  const [rect, setRect] = useState(imageRef?.current?.getBoundingClientRect());
+
+  // Update rect when window resizes
+  useEffect(() => {
+    const handleResize = () => {
+      if (imageRef?.current) {
+        setRect(imageRef.current.getBoundingClientRect());
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    // Clean up the event listener
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [imageRef]); // This effect depends on imageRef
 
   const circles = useMemo(() => {
     if (!processImageData?.defect_batches || !rect) return [];
+
+    // Create a map for faster lookup of stored marks
+    const marksMap = new Map();
+    marks.forEach((mark) => {
+      marksMap.set(mark.file_name, mark);
+      marksMap.set(mark.file_name + MARKERS.zoom.name, mark);
+    });
+
     return processImageData.defect_batches
       .flatMap((defect_batch) => defect_batch.defect_files)
       .map((file) => {
         const dx = Math.round(file.norm_x_center * rect.width * 100) / 100;
         const dy = Math.round(file.norm_y_center * rect.height * 100) / 100;
+
         const stored_mark =
-          marks.find((mark) => mark.file_name === file.file_name) ||
-          marks.find(
-            (mark) =>
-              mark.file_name === file.file_name &&
-              mark.file_name === file.file_name + MARKERS.zoom.name,
-          );
+          marksMap.get(file.file_name) ||
+          marksMap.get(file.file_name + MARKERS.zoom.name);
+
         return {
           id: file.file_name,
           cx: dx,
@@ -42,7 +64,7 @@ const useMarkCanvas = () => {
           color: stored_mark?.marker.color || MARKERS.temp.color,
         };
       });
-  }, [processImageData, marks, rect]);
+  }, [processImageData, marks, rect]); // Only recompute when these change
 
   return {
     state: { circles },


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

DotCanvas drawn on top of image not updating dot coordinates after windowresize

## Solution / Fixes

Add event listener to listen for windowresize and update the dot coordinates
Optimize speed calculation by converting to Map.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
