### PR TITLE
BUG: DB Model uuid callable causes static, change str to uuid type

### DIFF
--- a/backend/src/apis/v2/schemas/files.py
+++ b/backend/src/apis/v2/schemas/files.py
@@ -1,9 +1,10 @@
+from uuid import UUID
 from pydantic import BaseModel
 
 from schemas.chips_data import DefectBatch
 
 
 class DefectBatchDirectory(BaseModel):
-    unique_id: str
+    unique_id: UUID
     directory: str
     defect_batches: list[DefectBatch] = []

--- a/backend/src/db/models/chip_lot_details.py
+++ b/backend/src/db/models/chip_lot_details.py
@@ -1,4 +1,4 @@
-import uuid
+from uuid import uuid4, UUID
 from datetime import datetime as dt
 from sqlalchemy import String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -7,9 +7,7 @@ from db.base import Base
 
 
 class ChipLotDetails(Base):
-    id: Mapped[str] = mapped_column(
-        primary_key=True, default=str(uuid.uuid4()), index=True
-    )
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4, index=True)
     date_created: Mapped[dt] = mapped_column(default=func.now())
     date_updated: Mapped[dt] = mapped_column(default=func.now(), onupdate=func.now())
     lot_no: Mapped[str] = mapped_column(String(10), index=True)


### PR DESCRIPTION
## Previous Context

> (Optional: Add links or references to related issues/tickets)

resolves #0000

## Description

> Provide a brief or detailed explanation of the issue (Problem and Impact).

Upload returns error showing same unique ID when running another image

## Solution / Fixes

> Summarize the key changes and why this approach was taken.

uuid callable in model sqlalchemy causes static scalar value for subsequent injects.
remove callable and change data type from str to UUID

## Type of Change

- [ ] Feature: Adding new functionality or enhancing existing features.
- [X] Bug Fix: Fixing a defect or issue in the code.
- [ ] Hotfix: Quick patch for critical issues in production.
- [ ] Documentation: Updates or improvements to documentation.
- [ ] Refactor: Code changes that improve structure without altering functionality.
- [ ] Security: Resolving vulnerabilities or enhancing security measures.
- [ ] UI/UX: Improving the user interface or user experience.
- [ ] Performance: Optimizing code for speed, efficiency, or memory usage.
- [ ] Build/CI: Changes to build scripts, CI/CD pipelines, or dependencies.
- [ ] Testing: Adding or updating test cases and testing infrastructure.
- [ ] Cleanup: Removing unused code, files, or tech debt.
