### PR TITLE
BUG: fix image caching in useImageProcess

### DIFF
--- a/frontend/src/features/info-bar/hooks/useImageProcess.js
+++ b/frontend/src/features/info-bar/hooks/useImageProcess.js
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { uploadImage } from "@/services/api_files";
 import { useShallow } from "zustand/react/shallow";
 import useMarking from "@/hooks/useMarking";
-import { MARKERS } from "@/core/constants";
+import { useColorStore } from "@/store/color";
 
 const useImageMutation = ({ setError }) => {
   const queryClient = useQueryClient();
@@ -18,7 +18,7 @@ const useImageMutation = ({ setError }) => {
     onError: (error) => {
       console.log(error.message);
       setError(error.message);
-      queryClient.removeQueries(["processedImageData"]); // Clear cache on error
+      queryClient.removeQueries(["processedImageData"]);
     },
   });
 };
@@ -34,6 +34,7 @@ const useImageProcess = () => {
       setError: state.setError,
     })),
   );
+  const colors = useColorStore((state) => state.colors);
 
   const { mutateAsync: processImage } = useImageMutation({ setError });
 
@@ -49,17 +50,25 @@ const useImageProcess = () => {
             const filteredDefectFiles = data.file_data_batches.flatMap(
               (batch) =>
                 batch.data_files
-                  .filter((file) => file.defect_mode !== "temp") // Filter out 'temp' defect_mode
+                  .filter((file) => file.defect_mode !== "temp")
                   .map((file) => ({
                     file_name: file.file_name,
                     defect_mode: file.defect_mode,
                   })),
             );
             filteredDefectFiles.forEach(({ file_name, defect_mode }) => {
-              addMark(
-                file_name,
-                MARKERS.colors.find((color) => color.name === defect_mode),
+              const colorObj = colors.find(
+                (color) => color.defect_label === defect_mode,
               );
+              if (colorObj) {
+                addMark(file_name, {
+                  name: colorObj.defect_label,
+                  color: colorObj.hex_color,
+                  radius: 1,
+                });
+              } else {
+                console.warn(`No color found for defect_mode: ${defect_mode}`);
+              }
             });
           }
         },

--- a/frontend/src/features/info-bar/hooks/useImageProcess.js
+++ b/frontend/src/features/info-bar/hooks/useImageProcess.js
@@ -60,14 +60,12 @@ const useImageProcess = () => {
               const colorObj = colors.find(
                 (color) => color.defect_label === defect_mode,
               );
-              if (colorObj) {
-                addMark(file_name, {
-                  name: colorObj.defect_label,
-                  color: colorObj.hex_color,
-                  radius: 1,
-                });
-              } else {
-                console.warn(`No color found for defect_mode: ${defect_mode}`);
+              if (!colorObj) return;
+              addMark(file_name, {
+                name: colorObj.defect_label,
+                color: colorObj.hex_color,
+                radius: 1,
+              });
               }
             });
           }


### PR DESCRIPTION
## Previous Context

> (Optional: Add links or references to related issues/tickets)

resolves #0000

## Description

> Provide a brief or detailed explanation of the issue (Problem and Impact).

image cannot cache after reupload the image due to the color

## Solution / Fixes

> Summarize the key changes and why this approach was taken.

use colors array from color store to enable caching during reupload

## Type of Change

- [ ] Feature: Adding new functionality or enhancing existing features.
- [X] Bug Fix: Fixing a defect or issue in the code.
- [ ] Hotfix: Quick patch for critical issues in production.
- [ ] Documentation: Updates or improvements to documentation.
- [ ] Refactor: Code changes that improve structure without altering functionality.
- [ ] Security: Resolving vulnerabilities or enhancing security measures.
- [ ] UI/UX: Improving the user interface or user experience.
- [ ] Performance: Optimizing code for speed, efficiency, or memory usage.
- [ ] Build/CI: Changes to build scripts, CI/CD pipelines, or dependencies.
- [ ] Testing: Adding or updating test cases and testing infrastructure.
- [ ] Cleanup: Removing unused code, files, or tech debt.
